### PR TITLE
Add the no repeat option when booking a new resource.

### DIFF
--- a/app/assets/javascripts/mybookings/application.js
+++ b/app/assets/javascripts/mybookings/application.js
@@ -9,12 +9,14 @@
 //= require fullcalendar
 //= require fullcalendar/locale-all
 //= require bootstrap-datetimepicker
+//= require mybookings/mybookings
 //= require mybookings/availability_calendar
 //= require mybookings/bookings_calendar
-//= require mybookings/datetimepicker
 //= require mybookings/chart
-//= require mybookings/use_by_resource_chart
+//= require mybookings/dynamic_form
 //= require mybookings/use_by_hour_chart
+//= require mybookings/use_by_resource_chart
+//= require mybookings/datetimepicker
 //= require select2
 //= require select2_i18n_en
 //= require select2_i18n_es

--- a/app/assets/javascripts/mybookings/availability_calendar.js.coffee
+++ b/app/assets/javascripts/mybookings/availability_calendar.js.coffee
@@ -1,5 +1,3 @@
-window.Mybookings ||= {}
-
 class Mybookings.AvailabilityCalendar
   @render: (selector, resourceInputSelector, startDateInputSelector, endDateInputSelector, locale = "en") ->
     # TODO: review that dirty hack to deal with turbolinks

--- a/app/assets/javascripts/mybookings/bookings_calendar.js.coffee
+++ b/app/assets/javascripts/mybookings/bookings_calendar.js.coffee
@@ -1,5 +1,3 @@
-window.Mybookings ||= {}
-
 class Mybookings.BookingsCalendar
   @render: (selector, eventsUrl, locale='en') ->
     # TODO: review that dirty hack to deal with turbolinks

--- a/app/assets/javascripts/mybookings/chart.js.coffee
+++ b/app/assets/javascripts/mybookings/chart.js.coffee
@@ -1,5 +1,3 @@
-window.Mybookings ||= {}
-
 class Mybookings.Chart
   constructor: (@selector, @resourceTypeInputSelector) ->
 

--- a/app/assets/javascripts/mybookings/dynamic_form.js.coffee
+++ b/app/assets/javascripts/mybookings/dynamic_form.js.coffee
@@ -1,0 +1,56 @@
+class Mybookings.DynamicForm
+  @ENABLES_DATA_ATTRIBUTE: 'dynamic-form-enables-with'
+  @DISABLES_DATA_ATTRIBUTE: 'dynamic-form-disables-with'
+  @ENABLES_SELECTOR: '[data-dynamic-form-enables-with]'
+  @DISABLES_SELETOR: '[data-dynamic-form-disables-with]'
+  @HIDE_ELEMENT_SELECTOR: '.js-dynamic-form-element-to-hide'
+
+  constructor: (form, events='change') ->
+    @form = form
+    $(@form).on events, @handleChange
+    @render()
+
+  handleChange: (event) =>
+    @render()
+
+  render: ->
+    @processEnableElementsInForm()
+    @processDisableElementsInForm()
+
+  processEnableElementsInForm: ->
+    for element in @findEnableElementsInForm()
+      if @passConditions(element, DynamicForm.ENABLES_DATA_ATTRIBUTE)
+        @makeVisible(element)
+      else
+        @makeInvisible(element)
+
+  processDisableElementsInForm: ->
+    for element in @findDisableElementsInForm()
+      if @passConditions(element, DynamicForm.DISABLES_DATA_ATTRIBUTE)
+        @makeInvisible(element)
+      else
+        @makeVisible(element)
+
+  findEnableElementsInForm: ->
+    $(DynamicForm.ENABLES_SELECTOR, $(@form)).get().reverse()
+
+  findDisableElementsInForm: ->
+    $(DynamicForm.DISABLES_SELETOR, $(@form)).get().reverse()
+
+  passConditions: (element, attribute) ->
+    conditions = $(element).data(attribute)
+    [selector, values] = conditions.split('=')
+    options = values.split('||')
+    options.indexOf($(selector).val()) != -1
+
+  makeVisible: (element) ->
+    $(element).prop('disabled', false)
+    $(element).closest(DynamicForm.HIDE_ELEMENT_SELECTOR).show()
+
+  makeInvisible: (element) ->
+    $(element).prop('disabled', true)
+    $(element).closest(DynamicForm.HIDE_ELEMENT_SELECTOR).hide()
+
+$(document).on 'turbolinks:load', ->
+  $.map $('[data-behavior~="dynamic-form"]'), (item) ->
+    new Mybookings.DynamicForm(item, 'change')

--- a/app/assets/javascripts/mybookings/mybookings.js.coffee
+++ b/app/assets/javascripts/mybookings/mybookings.js.coffee
@@ -1,0 +1,1 @@
+window.Mybookings ||= {}

--- a/app/assets/javascripts/mybookings/use_by_hour_chart.js.coffee
+++ b/app/assets/javascripts/mybookings/use_by_hour_chart.js.coffee
@@ -1,5 +1,3 @@
-window.Mybookings ||= {}
-
 class Mybookings.UseByHourChart extends Mybookings.Chart
 
   drawChar: (dataset) =>

--- a/app/assets/javascripts/mybookings/use_by_resource_chart.js.coffee
+++ b/app/assets/javascripts/mybookings/use_by_resource_chart.js.coffee
@@ -1,5 +1,3 @@
-window.Mybookings ||= {}
-
 class Mybookings.UseByResourceChart extends Mybookings.Chart
 
   drawChar: (dataset) =>

--- a/app/models/mybookings/booking.rb
+++ b/app/models/mybookings/booking.rb
@@ -31,6 +31,8 @@ module Mybookings
     def self.new_for_user user, params, event_type
       booking = self.new(params)
       booking.user = user
+      # It is not a repeat booking, we assign it daily
+      # and leave the until_date field blank.
       booking.recurrent_type = 'daily' if booking.is_a_no_repeat_booking?
       booking.generate_events(event_type) if booking.valid?
 

--- a/app/models/mybookings/booking.rb
+++ b/app/models/mybookings/booking.rb
@@ -13,7 +13,7 @@ module Mybookings
     delegate :count, to: :events, prefix: true
     delegate :name, :extension, :notifications_emails, :notifications_email_from, :limit_days_for_feedback, :minutes_in_advance, :minutes_of_grace, to: :resource_type, prefix: true
 
-    validates :start_date, :end_date, :proposed_resource, :recurrent_type, presence: true
+    validates :start_date, :end_date, :proposed_resource, presence: true
     validates :until_date, presence: true, if: :is_a_recurring_booking?
     validate :the_booking_period_is_valid, if: :is_a_recurring_booking?
     validate :the_event_duration_is_valid
@@ -31,6 +31,7 @@ module Mybookings
     def self.new_for_user user, params, event_type
       booking = self.new(params)
       booking.user = user
+      booking.recurrent_type = 'daily' if booking.is_a_no_repeat_booking?
       booking.generate_events(event_type) if booking.valid?
 
       booking
@@ -85,6 +86,10 @@ module Mybookings
     def destroy
       return false if has_events?
       super
+    end
+
+    def is_a_no_repeat_booking?
+      until_date.blank? && recurrent_type.blank?
     end
 
     private

--- a/app/views/mybookings/bookings/new.html.haml
+++ b/app/views/mybookings/bookings/new.html.haml
@@ -5,7 +5,10 @@
 
 .row
   .col-xs-12.col-sm-6
-    = simple_form_for [@resource_type, @booking], url: resource_type_bookings_path(@resource_type, @booking) do |f|
+    = simple_form_for [@resource_type, @booking],
+        url: resource_type_bookings_path(@resource_type, @booking),
+        data: { behavior: 'dynamic-form' } do |f|
+
       = render_model_base_errors f.object
 
       .panel.panel-default
@@ -22,9 +25,17 @@
 
           .row
             .col-xs-12.col-sm-6
-              = f.input :recurrent_type, collection: recurrent_types_list, as: :select, include_blank: false, hint: t('mybookings.bookings.hints.recurring_hint')
-            .col-xs-12.col-sm-6
-              = f.input :until_date, as: :datetimepicker, hint: t('mybookings.bookings.hints.until_date_hint')
+              = f.input :recurrent_type,
+                  collection: recurrent_types_list,
+                  as: :select,
+                  include_blank: t('mybookings.bookings.recurrent_types.no_repeat'),
+                  selected: '',
+                  hint: t('mybookings.bookings.hints.recurring_hint')
+            .col-xs-12.col-sm-6.js-dynamic-form-element-to-hide
+              = f.input :until_date,
+                  as: :datetimepicker,
+                  hint: t('mybookings.bookings.hints.until_date_hint'),
+                  input_html: { data: { 'dynamic-form-disables-with': '#booking_recurrent_type=' } }
 
           = f.input :comment, as: :text, input_html: { rows: 3 }, hint: t('mybookings.bookings.hints.comment_hint')
 

--- a/app/views/mybookings/bookings/new.html.haml
+++ b/app/views/mybookings/bookings/new.html.haml
@@ -32,6 +32,8 @@
                   selected: '',
                   hint: t('mybookings.bookings.hints.recurring_hint')
             .col-xs-12.col-sm-6.js-dynamic-form-element-to-hide
+              -# The value '#booking_recurrent_type=""' does not work because it isn't
+              -# an empty value. It is a string with two double quotes.
               = f.input :until_date,
                   as: :datetimepicker,
                   hint: t('mybookings.bookings.hints.until_date_hint'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
         title: 'New booking'
         title_with_resource_type_name: 'New booking of %{resource_type_name}'
       recurrent_types:
+        no_repeat: 'No repeat'
         daily: 'Daily'
         weekly: 'Weekly'
         monthly: 'Monthly'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -148,6 +148,7 @@ es:
         title: 'Nueva reserva'
         title_with_resource_type_name: 'Nueva reserva de %{resource_type_name}'
       recurrent_types:
+        no_repeat: 'No repetir'
         daily: 'Diariamente'
         weekly: 'Semanalmente'
         monthly: 'Mensualmente'

--- a/spec/features/bookings.feature
+++ b/spec/features/bookings.feature
@@ -8,6 +8,7 @@ Feature: Bookings management
     Given a signed in user
     When I go to the bookings page
     And I can start to create a booking
+    And I cannot see the until date field when is selected the no repeat option
     And I cannot book an available resource for more than 4 hours
     And I can book an available resource
     And I can see that the booking has been created

--- a/spec/steps/bookings_steps.rb
+++ b/spec/steps/bookings_steps.rb
@@ -16,6 +16,11 @@ step 'I can start to create a booking' do
   end
 end
 
+step 'I cannot see the until date field when is selected the no repeat option' do
+  expect(page).to have_select('Repeat event', selected: 'No repeat')
+  expect(page).to have_css('.js-dynamic-form-element-to-hide', visible: false)
+end
+
 step 'I cannot book an available resource for more than 4 hours' do
   select 'PCV1', from: 'Resource'
 

--- a/spec/steps/bookings_steps.rb
+++ b/spec/steps/bookings_steps.rb
@@ -18,7 +18,7 @@ end
 
 step 'I cannot see the until date field when is selected the no repeat option' do
   expect(page).to have_select('Repeat event', selected: 'No repeat')
-  expect(page).to have_css('.js-dynamic-form-element-to-hide', visible: false)
+  expect(page).to_not have_content('Until date')
 end
 
 step 'I cannot book an available resource for more than 4 hours' do


### PR DESCRIPTION
In this pull request, I have added the "no repeat" option to the "repeat event" select when the user creates a new booking in the application. If this option is selected the "until date" field is hidden.