### PR TITLE
Add hide comment field option to resource types

### DIFF
--- a/app/models/mybookings/booking.rb
+++ b/app/models/mybookings/booking.rb
@@ -11,7 +11,7 @@ module Mybookings
 
     delegate :email, :first_name, :last_name, to: :user, prefix: true
     delegate :count, to: :events, prefix: true
-    delegate :name, :extension, :notifications_emails, :notifications_email_from, :limit_days_for_feedback, :minutes_in_advance, :minutes_of_grace, to: :resource_type, prefix: true
+    delegate :name, :extension, :notifications_emails, :notifications_email_from, :limit_days_for_feedback, :minutes_in_advance, :minutes_of_grace, :hide_comment_field, to: :resource_type, prefix: true
 
     validates :start_date, :end_date, :proposed_resource, :recurrent_type, presence: true
     validates :until_date, presence: true, if: :is_a_recurring_booking?
@@ -85,6 +85,10 @@ module Mybookings
     def destroy
       return false if has_events?
       super
+    end
+
+    def can_display_comment_field?
+      !resource_type_hide_comment_field
     end
 
     private

--- a/app/views/mybookings/backend/resource_types/_form_fields.html.haml
+++ b/app/views/mybookings/backend/resource_types/_form_fields.html.haml
@@ -25,7 +25,7 @@
         = f.input :limit_days_for_recurring_events, min_max: true, hint: t('mybookings.backend.resource_types.hints.limit_days_for_recurring_events')
       .col-xs-12.col-sm-4
         = f.input :limit_days_for_feedback, min_max: true, hint: t('mybookings.backend.resource_types.hints.limit_days_for_feedback')
-      .col-xs-12.col-sm-12
+      .col-xs-12
         = f.input :hide_comment_field, hint: t('mybookings.backend.resource_types.hints.hide_comment_field')
 
 .panel.panel-default

--- a/app/views/mybookings/backend/resource_types/_form_fields.html.haml
+++ b/app/views/mybookings/backend/resource_types/_form_fields.html.haml
@@ -25,7 +25,7 @@
         = f.input :limit_days_for_recurring_events, min_max: true, hint: t('mybookings.backend.resource_types.hints.limit_days_for_recurring_events')
       .col-xs-12.col-sm-4
         = f.input :limit_days_for_feedback, min_max: true, hint: t('mybookings.backend.resource_types.hints.limit_days_for_feedback')
-      .col-xs-12.col-sm-4
+      .col-xs-12.col-sm-12
         = f.input :hide_comment_field, hint: t('mybookings.backend.resource_types.hints.hide_comment_field')
 
 .panel.panel-default

--- a/app/views/mybookings/backend/resource_types/_form_fields.html.haml
+++ b/app/views/mybookings/backend/resource_types/_form_fields.html.haml
@@ -25,6 +25,8 @@
         = f.input :limit_days_for_recurring_events, min_max: true, hint: t('mybookings.backend.resource_types.hints.limit_days_for_recurring_events')
       .col-xs-12.col-sm-4
         = f.input :limit_days_for_feedback, min_max: true, hint: t('mybookings.backend.resource_types.hints.limit_days_for_feedback')
+      .col-xs-12.col-sm-4
+        = f.input :hide_comment_field, hint: t('mybookings.backend.resource_types.hints.hide_comment_field')
 
 .panel.panel-default
   .panel-heading

--- a/app/views/mybookings/bookings/new.html.haml
+++ b/app/views/mybookings/bookings/new.html.haml
@@ -26,7 +26,8 @@
             .col-xs-12.col-sm-6
               = f.input :until_date, as: :datetimepicker, hint: t('mybookings.bookings.hints.until_date_hint')
 
-          = f.input :comment, as: :text, input_html: { rows: 3 }, hint: t('mybookings.bookings.hints.comment_hint')
+          - if @booking.can_display_comment_field?
+            = f.input :comment, as: :text, input_html: { rows: 3 }, hint: t('mybookings.bookings.hints.comment_hint')
 
       = render partial: "resource_type_extension_#{@booking.resource_type_extension.downcase}_new", locals: { form: f }
 

--- a/app/views/mybookings/bookings/show.haml
+++ b/app/views/mybookings/bookings/show.haml
@@ -12,13 +12,14 @@
           %h4= t('.creation_date')
           %p= l(@booking.created_at, format: :long)
 
-        .col-xs-12.col-sm-6
-          %h4= t('.comment')
-          - unless @booking.comment.blank?
-            %p= @booking.comment
-          - else
-            %p
-              %em= t('.no_comments')
+        - if @booking.can_display_comment_field?
+          .col-xs-12.col-sm-6
+            %h4= t('.comment')
+            - unless @booking.comment.blank?
+              %p= @booking.comment
+            - else
+              %p
+                %em= t('.no_comments')
 
       %hr
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
           options: Options
           roles: 'Roles who can book resources of this type'
         hints:
+          hide_comment_field: Tick the checkbox if you want to hide the comment field on the new booking page.
           limit_days_for_feedback: The maximum number of days allowed for users to submit feedback for an event.
           limit_days_for_recurring_events: The maximum number of days between the start date and the end date of an event.
           limit_hours_duration: The maximum number of hours allowed for events.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
           options: Options
           roles: 'Roles who can book resources of this type'
         hints:
-          hide_comment_field: Tick the checkbox if you want to hide the comment field on the new booking page.
+          hide_comment_field: Mark the checkbox if you want to hide the comment field on the new booking page.
           limit_days_for_feedback: The maximum number of days allowed for users to submit feedback for an event.
           limit_days_for_recurring_events: The maximum number of days between the start date and the end date of an event.
           limit_hours_duration: The maximum number of hours allowed for events.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -82,6 +82,7 @@ es:
           options: Opciones
           roles: 'Roles que pueden reservar recursos de este tipo'
         hints:
+          hide_comment_field: Marque la casilla si desea ocultar el campo de observaciones en la pagina de nueva reserva.
           limit_days_for_feedback: El máximo número de días para que los usuarios envíen feedback de un evento.
           limit_days_for_recurring_events: El máximo número de días entre la fecha de inicio y la fecha de fin de un evento.
           limit_hours_duration: El máximo número de horas de duración para los eventos.

--- a/config/locales/fields.en.yml
+++ b/config/locales/fields.en.yml
@@ -24,6 +24,7 @@ en:
         bookings: Bookings
       mybookings/resource_type:
         extension: Resource type extension
+        hide_comment_field: 'Hide the comment field'
         id: ID
         limit_days_for_feedback: Limit days for feedback
         limit_days_for_recurring_events: Limit days for recurring events

--- a/config/locales/fields.en.yml
+++ b/config/locales/fields.en.yml
@@ -24,7 +24,7 @@ en:
         bookings: Bookings
       mybookings/resource_type:
         extension: Resource type extension
-        hide_comment_field: 'Hide the comment field'
+        hide_comment_field: Hide the comment field
         id: ID
         limit_days_for_feedback: Limit days for feedback
         limit_days_for_recurring_events: Limit days for recurring events

--- a/config/locales/fields.es.yml
+++ b/config/locales/fields.es.yml
@@ -24,7 +24,7 @@ es:
         bookings: Reservas
       mybookings/resource_type:
         extension: Extensión del tipo de recurso
-        hide_comment_field: Ocular el campo observaciones
+        hide_comment_field: Ocultar el campo observaciones
         id: ID
         limit_days_for_feedback: Límite de días para envío de feedback
         limit_days_for_recurring_events: Máximo número de días para eventos recurrentes

--- a/config/locales/fields.es.yml
+++ b/config/locales/fields.es.yml
@@ -24,6 +24,7 @@ es:
         bookings: Reservas
       mybookings/resource_type:
         extension: Extensión del tipo de recurso
+        hide_comment_field: Ocular el campo observaciones
         id: ID
         limit_days_for_feedback: Límite de días para envío de feedback
         limit_days_for_recurring_events: Máximo número de días para eventos recurrentes

--- a/db/migrate/20180315163832_add_hide_comment_field_to_resource_type.rb
+++ b/db/migrate/20180315163832_add_hide_comment_field_to_resource_type.rb
@@ -1,0 +1,5 @@
+class AddHideCommentFieldToResourceType < ActiveRecord::Migration
+  def change
+    add_column :mybookings_resource_types, :hide_comment_field, :boolean
+  end
+end

--- a/db/migrate/20180315163832_add_hide_comment_field_to_resource_type.rb
+++ b/db/migrate/20180315163832_add_hide_comment_field_to_resource_type.rb
@@ -1,5 +1,5 @@
 class AddHideCommentFieldToResourceType < ActiveRecord::Migration
   def change
-    add_column :mybookings_resource_types, :hide_comment_field, :boolean
+    add_column :mybookings_resource_types, :hide_comment_field, :boolean, default: false
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 20180315163832) do
     t.integer  "limit_hours_duration",            default: 24
     t.integer  "limit_days_for_recurring_events", default: 365
     t.integer  "limit_days_for_feedback",         default: 7
-    t.boolean  "hide_comment_field"
+    t.boolean  "hide_comment_field",              default: false
   end
 
   add_index "mybookings_resource_types", ["deleted_at"], name: "index_mybookings_resource_types_on_deleted_at"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170406084301) do
+ActiveRecord::Schema.define(version: 20180315163832) do
 
   create_table "mybookings_bookings", force: :cascade do |t|
     t.integer  "user_id"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 20170406084301) do
     t.integer  "limit_hours_duration",            default: 24
     t.integer  "limit_days_for_recurring_events", default: 365
     t.integer  "limit_days_for_feedback",         default: 7
+    t.boolean  "hide_comment_field"
   end
 
   add_index "mybookings_resource_types", ["deleted_at"], name: "index_mybookings_resource_types_on_deleted_at"

--- a/spec/features/admins.feature
+++ b/spec/features/admins.feature
@@ -35,6 +35,8 @@ Feature: Admin
     And I can cancel the resource type
     And I can see that the resource type has been cancelled
     And I can see that the resources associated with the resource type has been canceled
+    And I can set the option of hiding the comment field of a resource type
+    And I can see that the new booking pages of this resource type do not show the comment field
 
   Scenario: Manage users as administrator
     Given a signed in administrator

--- a/spec/steps/backend_steps.rb
+++ b/spec/steps/backend_steps.rb
@@ -105,6 +105,12 @@ step 'I can see that the resources associated with the resource type has been ca
 end
 
 step 'I can set the option of hiding the comment field of a resource type' do
+  # Ensure the comment field is visible
+  step 'I go to the bookings page'
+  step 'I can start to create a booking'
+  expect(page).to have_content('Comment')
+
+  step 'I go to the manage page'
   step 'I click on Resource types menu item'
   find('tr', text: 'Virtual PC').click_link ('Edit')
   check 'Hide the comment field'

--- a/spec/steps/backend_steps.rb
+++ b/spec/steps/backend_steps.rb
@@ -68,7 +68,7 @@ end
 step 'I can add a new resource type' do
   click_link 'New resource type'
 
-  fill_in 'Resource type name', with: 'Virtual PC'
+  fill_in 'Resource type name', with: 'Online PC'
   select 'DefaultExtension', from: 'Resource type extension'
 
   click_button 'Create resource type'
@@ -102,6 +102,19 @@ step 'I can see that the resources associated with the resource type has been ca
   expect(page).to_not have_content('acmr_cancel')
   expect(page).to_not have_content('Disabled resource')
   expect(page).to_not have_content('ACMR5')
+end
+
+step 'I can set the option of hiding the comment field of a resource type' do
+  step 'I click on Resource types menu item'
+  find('tr', text: 'Virtual PC').click_link ('Edit')
+  check 'Hide the comment field'
+  click_button 'Update resource type'
+end
+
+step 'I can see that the new booking pages of this resource type do not show the comment field' do
+  step 'I go to the bookings page'
+  step 'I can start to create a booking'
+  expect(page).to_not have_content('Comment')
 end
 
 step 'I click on Users menu item' do


### PR DESCRIPTION
In this pull request, I've added the option to hide the comment field on the resource type administration page. If the user marks the option, the comment field will not be displayed on the form for creating a new booking for that resource type.